### PR TITLE
Fix required variable pool_idx that should not be

### DIFF
--- a/lib/kafka_connection.rb
+++ b/lib/kafka_connection.rb
@@ -5,7 +5,7 @@ require "kafka_connection/consumer"
 require "kafka_connection/pool"
 
 module KafkaConnection
-  def self.new(app_name:, env_name:, pool_idx:)
+  def self.new(app_name:, env_name:, pool_idx: 0)
     Connection.new(app_name: app_name, env_name: env_name, pool_idx: pool_idx)
   end
 


### PR DESCRIPTION
This argument is not supposed to be required, but it was missing a default value.