### PR TITLE
Allow non-SSL connection info in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ _Never_ place a repository access token in the Gemfile, or commit it to the repo
 This gem requires the following environment variables:
 
 - `KAFKA_BROKERS`: Comma-separated list of brokers. E.g. "kafka+ssl://hostname:9092"
-- `KAFKA_CA`: The CA certificate in PEM format.
-- `KAFKA_CERT`: The client's certificate in PEM format.
-- `KAFKA_PRIVATE_KEY`: The client's private key in PEM format.
+- `KAFKA_CA`: The CA certificate in PEM format. _(Required if a kafka+ssl broker is specified.)_
+- `KAFKA_CERT`: The client's certificate in PEM format. _(Required if a kafka+ssl broker is specified.)_
+- `KAFKA_PRIVATE_KEY`: The client's private key in PEM format. _(Required if a kafka+ssl broker is specified.)_
 
 The PEM-format keys are multi-line values and must not have their lines concatenated.
 If your environment does not make it easy to set variables containing newlines, you can use the string "\n" (acually containing a backslash) in place of newline characters.

--- a/lib/kafka_connection/connection.rb
+++ b/lib/kafka_connection/connection.rb
@@ -31,7 +31,7 @@ module KafkaConnection
 
     def check_environment!
       necessary_env_vars = %w(KAFKA_BROKERS)
-      if /kafka\+ssl:/.match(ENV['KAFKA_BROKERS'] || '')
+      if (ENV['KAFKA_BROKERS'] || '') =~ /kafka\+ssl:/
         necessary_env_vars += %w(KAFKA_CA KAFKA_CERT KAFKA_PRIVATE_KEY)
       end
       missing = necessary_env_vars.reject { |var| ENV[var] }

--- a/lib/kafka_connection/connection.rb
+++ b/lib/kafka_connection/connection.rb
@@ -3,18 +3,11 @@ require 'kafka'
 module KafkaConnection
   class Connection
     def initialize(app_name:, env_name:, pool_idx: 0)
-      missing = %w(KAFKA_BROKERS KAFKA_CA KAFKA_CERT KAFKA_PRIVATE_KEY).reject { |var|
-        ENV[var]
-      }
-      raise "#{missing.join(', ')} not set in the environment" unless missing.empty?
-
-      self.kafka_client = Kafka.new(
-        seed_brokers: ENV['KAFKA_BROKERS'].split(','),
-        client_id: [app_name, env_name, Socket.gethostname, Process.pid, pool_idx].join(':'),
-        ssl_ca_cert: multiline_env_var('KAFKA_CA'),
-        ssl_client_cert: multiline_env_var('KAFKA_CERT'),
-        ssl_client_cert_key: multiline_env_var('KAFKA_PRIVATE_KEY'),
-      )
+      self.app_name = app_name
+      self.env_name = env_name
+      self.pool_idx = pool_idx
+      check_environment!
+      self.kafka_client = Kafka.new kafka_configuration
     end
 
     def prefix_topic(topic)
@@ -32,11 +25,37 @@ module KafkaConnection
     private
 
     attr_accessor :kafka_client
+    attr_accessor :app_name
+    attr_accessor :env_name
+    attr_accessor :pool_idx
+
+    def check_environment!
+      necessary_env_vars = %w(KAFKA_BROKERS)
+      if /kafka\+ssl:/.match(ENV['KAFKA_BROKERS'] || '')
+        necessary_env_vars += %w(KAFKA_CA KAFKA_CERT KAFKA_PRIVATE_KEY)
+      end
+      missing = necessary_env_vars.reject { |var| ENV[var] }
+      raise "#{missing.join(', ')} not set in the environment" unless missing.empty?
+    end
+
+    def kafka_client_id
+      [app_name, env_name, Socket.gethostname, Process.pid, pool_idx].join(':')
+    end
+
+    def kafka_configuration
+      {
+        seed_brokers: ENV['KAFKA_BROKERS'].split(','),
+        client_id: kafka_client_id,
+        ssl_ca_cert: multiline_env_var('KAFKA_CA'),
+        ssl_client_cert: multiline_env_var('KAFKA_CERT'),
+        ssl_client_cert_key: multiline_env_var('KAFKA_PRIVATE_KEY'),
+      }
+    end
 
     # Attempts to extract multiline environment variables that have either real newlines or "\\n" as
     # line separators.
     def multiline_env_var(name)
-      ENV[name].split(/\\n|\n/).join("\n")
+      ENV[name].split(/\\n|\n/).join("\n") if ENV[name]
     end
   end
 end


### PR DESCRIPTION
Up to this point, only SSL connections were supported, so the `KAFKA_CA`, `KAFKA_CERT`, and `KAFAK_PRIVATE_KEY` environment variables were required.

Now, these environment variables are only required if an SSL broker is configured.

It does this by looking in the `KAFKA_BROKERS` env variable value to see if there's a "kafka+ssl:"-protocol broker.