### PR TITLE
Fix client ID

### DIFF
--- a/lib/kafka_connection/connection.rb
+++ b/lib/kafka_connection/connection.rb
@@ -38,8 +38,15 @@ module KafkaConnection
       raise "#{missing.join(', ')} not set in the environment" unless missing.empty?
     end
 
+    ##
+    # Creates a string that identifies this Kafka client. This is a concatenation of all information
+    # that will help us identify the source of a connection.
+    # Colons are not allowed in client ID strings (it causes a Kafka UnknownError), so we must
+    # suppress them.
     def kafka_client_id
-      [app_name, env_name, Socket.gethostname, Process.pid, pool_idx].join(':')
+      [app_name, env_name, Socket.gethostname, Process.pid, pool_idx].map { |s|
+        s.to_s.gsub('_', '-').gsub(':', '.')
+      }.join('_')
     end
 
     def kafka_configuration

--- a/lib/kafka_connection/connection.rb
+++ b/lib/kafka_connection/connection.rb
@@ -45,7 +45,7 @@ module KafkaConnection
     # suppress them.
     def kafka_client_id
       [app_name, env_name, Socket.gethostname, Process.pid, pool_idx].map { |s|
-        s.to_s.gsub('_', '-').gsub(':', '.')
+        s.to_s.tr('_', '-').tr(':', '.')
       }.join('_')
     end
 

--- a/spec/kafka_connection_spec.rb
+++ b/spec/kafka_connection_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe KafkaConnection do
   subject(:instance) {
     described_class.new(app_name: app_name, env_name: env_name, pool_idx: pool_idx)
   }
-  let(:app_name) { "app" }
+  let(:app_name) { "app_22_is_great_app" }
   let(:env_name) { "test" }
   let(:pool_idx) { 12 }
 
@@ -45,7 +45,7 @@ RSpec.describe KafkaConnection do
       it 'creates a Kafka object' do
         expect(Kafka).to receive(:new).with(
           seed_brokers: ['host1:123', 'host2:234'],
-          client_id: "#{app_name}:#{env_name}:#{Socket.gethostname}:#{Process.pid}:#{pool_idx}",
+          client_id: "app-22-is-great-app_#{env_name}_#{Socket.gethostname}_#{Process.pid}_#{pool_idx}",
           ssl_ca_cert: "-----BEGIN CA CERTIFICATE-----\nabcd\n---END---",
           ssl_client_cert: "-----BEGIN CERTIFICATE-----\nabcd\n---END---",
           ssl_client_cert_key: 'CERT_KEY',

--- a/spec/kafka_connection_spec.rb
+++ b/spec/kafka_connection_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe KafkaConnection do
       it 'creates a Kafka object' do
         expect(Kafka).to receive(:new).with(
           seed_brokers: ['host1:123', 'host2:234'],
-          client_id: "app-22-is-great-app_#{env_name}_#{Socket.gethostname}_#{Process.pid}_#{pool_idx}",
+          client_id:
+            "app-22-is-great-app_#{env_name}_#{Socket.gethostname}_#{Process.pid}_#{pool_idx}",
           ssl_ca_cert: "-----BEGIN CA CERTIFICATE-----\nabcd\n---END---",
           ssl_client_cert: "-----BEGIN CERTIFICATE-----\nabcd\n---END---",
           ssl_client_cert_key: 'CERT_KEY',


### PR DESCRIPTION
Kafka client IDs can't contain colons. They cause a Kafka::UnknownError and the kafka logs have the following:

```
org.apache.kafka.common.KafkaException: Error creating mbean attribute for metricName :MetricName [name=byte-rate, group=Fetch, description=Tracking byte-rate per user/client-id, tags={client-id=hangman.PointUpdater:development:artax.local:81757:0, user=}]
        at org.apache.kafka.common.metrics.JmxReporter.addAttribute(JmxReporter.java:113)
        at org.apache.kafka.common.metrics.JmxReporter.metricChange(JmxReporter.java:76)
        at org.apache.kafka.common.metrics.Metrics.registerMetric(Metrics.java:383)
        at org.apache.kafka.common.metrics.Sensor.add(Sensor.java:179)
        at org.apache.kafka.common.metrics.Sensor.add(Sensor.java:164)
        at kafka.server.SensorAccess.getOrCreate(SensorAccess.scala:68)
        at kafka.server.ClientQuotaManager.getOrCreateQuotaSensors(ClientQuotaManager.scala:352)
        at kafka.server.ClientQuotaManager.recordAndMaybeThrottle(ClientQuotaManager.scala:179)
        at kafka.server.KafkaApis.kafka$server$KafkaApis$$sendResponseCallback$3(KafkaApis.scala:526)
        at kafka.server.KafkaApis$$anonfun$handleFetchRequest$1.apply(KafkaApis.scala:542)
        at kafka.server.KafkaApis$$anonfun$handleFetchRequest$1.apply(KafkaApis.scala:542)
        at kafka.server.ReplicaManager.fetchMessages(ReplicaManager.scala:497)
        at kafka.server.KafkaApis.handleFetchRequest(KafkaApis.scala:534)
        at kafka.server.KafkaApis.handle(KafkaApis.scala:79)
        at kafka.server.KafkaRequestHandler.run(KafkaRequestHandler.scala:60)
        at java.lang.Thread.run(Thread.java:745)
Caused by: javax.management.MalformedObjectNameException: Invalid character ':' in value part of property
        at javax.management.ObjectName.construct(ObjectName.java:618)
        at javax.management.ObjectName.<init>(ObjectName.java:1382)
        at org.apache.kafka.common.metrics.JmxReporter$KafkaMbean.<init>(JmxReporter.java:169)
        at org.apache.kafka.common.metrics.JmxReporter.addAttribute(JmxReporter.java:108)
```